### PR TITLE
fix!: required credentials and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,18 @@ The proxy is highly configurable using the following environment variables:
 
 | Environment Variable | Default Value                          | Description                                                          |
 | -------------------- | -------------------------------------- | -------------------------------------------------------------------- |
-| `PORT_PROXY`         | `31280`                                | The port on which the proxy server listens for traffic.              |
-| `PORT_PROBES`        | `31281`                                | The port on which the probe server (health and readiness) listens.   |
-| `SHUTDOWN_TIMEOUT`   | `5`                                    | The timeout duration in seconds for graceful shutdown of the server. |
-| `READINESS_URL`      | `https://cloudflare.com/cdn-cgi/trace` | The URL to check for network readiness (internet connection check).  |
-| `USERNAME`           | `proxy`                                | The username for Basic Authentication on the proxy.                  |
-| `PASSWORD`           | `secret`                               | The password for Basic Authentication on the proxy.                  |
+| `DEBUG`              | `false`                               | Enables debug mode if set to `true`.                                 |
+| `PORT_PROXY`         | `31280`                               | The port on which the proxy server listens for traffic.              |
+| `PORT_PROBES`        | `31281`                               | The port on which the probe server (health and readiness) listens.   |
+| `SHUTDOWN_TIMEOUT`   | `5s`                                  | The timeout duration (in seconds) for graceful shutdown of the server. |
+| `READINESS_URL`      | `https://cloudflare.com/cdn-cgi/trace`| The URL to check for network readiness (internet connection check).  |
+| `USERNAME`           | *required*                            | The username for Basic Authentication on the proxy. Must be set.     |
+| `PASSWORD`           | *required*                            | The password for Basic Authentication on the proxy. Must be set.     |
+
+### Notes
+- **Mandatory Variables:** Both `USERNAME` and `PASSWORD` are required for the proxy to run. If either is not set, the application will exit with an error.
+- **Shutdown Timeout Format:** Ensure `SHUTDOWN_TIMEOUT` is provided in seconds (e.g., `5s`).
+                |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The proxy is highly configurable using the following environment variables:
 ### Notes
 - **Mandatory Variables:** Both `USERNAME` and `PASSWORD` are required for the proxy to run. If either is not set, the application will exit with an error.
 - **Shutdown Timeout Format:** Ensure `SHUTDOWN_TIMEOUT` is provided in seconds (e.g., `5s`).
-                |
 
 ## Usage
 

--- a/main.go
+++ b/main.go
@@ -46,8 +46,6 @@ const (
 	portProbesDefault      = "31281"
 	shutdownTimeoutDefault = 5 * time.Second
 	readinessURLDefault    = "https://cloudflare.com/cdn-cgi/trace"
-	usernameDefault        = "proxy"
-	passwordDefault        = "secret"
 )
 
 func main() {
@@ -57,8 +55,14 @@ func main() {
 	portProbes := getEnv("PORT_PROBES", portProbesDefault)
 	shutdownTimeoutS := getEnv("SHUTDOWN_TIMEOUT", shutdownTimeoutDefault.String())
 	readinessURL := getEnv("READINESS_URL", readinessURLDefault)
-	username := getEnv("USERNAME", usernameDefault)
-	password := getEnv("PASSWORD", passwordDefault)
+	username := getEnv("USERNAME")
+	password := getEnv("PASSWORD")
+
+	// Check if the username and password are set
+	if username == "" || password == "" {
+		slog.Error("Username and password must be set")
+		os.Exit(1)
+	}
 
 	// Parse the debug value
 	debug, err := strconv.ParseBool(debugS)

--- a/utils.go
+++ b/utils.go
@@ -31,10 +31,11 @@ import (
 	"os"
 )
 
-func getEnv(key, defaultValue string) string {
+// Gets environment variable with optional default value
+func getEnv(key string, defaultValue ...string) string {
 	value := os.Getenv(key)
-	if value == "" {
-		return defaultValue
+	if value == "" && len(defaultValue) != 0 {
+		return defaultValue[0]
 	}
 	return value
 }


### PR DESCRIPTION
This counts as a breaking change, since now both `USERNAME` and `PASSWORD` env vars ***MUST be provided***.